### PR TITLE
Update sub-layer frames when self.frame was updated by constraint

### DIFF
--- a/SwiftRangeSlider/RangeSlider.swift
+++ b/SwiftRangeSlider/RangeSlider.swift
@@ -163,7 +163,12 @@ enum Knob {
     upperThumbLayer.contentsScale = UIScreen.main.scale
     layer.addSublayer(upperThumbLayer)
   }
-  
+
+  override open func layoutSubviews() {
+    super.layoutSubviews()
+    updateLayerFrames()
+  }
+
   // MARK: Member Functions
   
   


### PR DESCRIPTION
```
  override open var frame: CGRect {
    didSet {
      updateLayerFrames()
    }
  }
```
**didSet** wasn't triggered when frame was updated by auto-layout contraints
we can get updated frame value in layoutSubviews()