### PR TITLE
#13, Add Property, KnobAnchorPosition to mimic the default UISlider.

### DIFF
--- a/SwiftRangeSlider/RangeSlider.swift
+++ b/SwiftRangeSlider/RangeSlider.swift
@@ -182,6 +182,14 @@ import QuartzCore
       updateLabelText()
     }
   }
+    
+  ///Whether the knob is clip to bounds.
+  open var knobAnchorPosition: KnobAnchorPosition = .center {
+    didSet {
+      updateTrackLayerFrameAndKnobPositions()
+    }
+  }
+    
   
   var previousLocation = CGPoint()
   var previouslySelectedKnob = Knob.Neither
@@ -490,11 +498,21 @@ import QuartzCore
     
     let percentage = percentageForValue(value)
     
-    let xPosition = bounds.width * percentage
+    var knobDeltaX: CGFloat = 0
+    var knobDeltaWidth:CGFloat = 0
+    
+    switch (knobAnchorPosition) {
+    case .inside:
+      knobDeltaX = (KnobSize / 2) - RangeSliderKnob.KnobDelta
+      knobDeltaWidth = -(KnobSize - (RangeSliderKnob.KnobDelta * 2))
+    case _: break
+    }
+    
+    let xPosition = (bounds.width + knobDeltaWidth) * percentage
     
     let yPosition = track.frame.midY
     
-    return CGPoint(x: xPosition, y: yPosition)
+    return CGPoint(x: xPosition + knobDeltaX, y: yPosition)
   }
   
   func percentageForValue(_ value: Double) -> CGFloat {

--- a/SwiftRangeSlider/RangeSliderKnob.swift
+++ b/SwiftRangeSlider/RangeSliderKnob.swift
@@ -16,7 +16,14 @@ enum Knob {
   case Both
 }
 
+public enum KnobAnchorPosition {
+  case inside
+  case center
+}
+
 class RangeSliderKnob: CALayer {
+  static var KnobDelta: CGFloat = 2.0
+    
   var highlighted: Bool = false {
     didSet {
       if let superLayer = superlayer, highlighted {
@@ -30,7 +37,7 @@ class RangeSliderKnob: CALayer {
   
   override func draw(in ctx: CGContext) {
     if let slider = rangeSlider {
-      let knobFrame = bounds.insetBy(dx: 2.0, dy: 2.0)
+      let knobFrame = bounds.insetBy(dx: RangeSliderKnob.KnobDelta, dy: RangeSliderKnob.KnobDelta)
       let cornerRadius = knobFrame.height * slider.curvaceousness / 2
       let knobPath = UIBezierPath(roundedRect: knobFrame, cornerRadius: cornerRadius)
       


### PR DESCRIPTION
I sugget adding a new property to mimic the default UISlider. Currently SwiftRangeSlider `Knob` anchor position is middle aligned, In constrast, the default UISlider anchor position is inside aligned.

Half of the `Knob` size (it is equal to radius) will be exceed the bounds.

It would be better library, if KnobAnchorPosition property added.