### PR TITLE
Add Property, knobHighlightable to mimic the default UISlider.

### DIFF
--- a/SwiftRangeSlider/RangeSlider.swift
+++ b/SwiftRangeSlider/RangeSlider.swift
@@ -183,6 +183,14 @@ import QuartzCore
     }
   }
   
+  ///Whether the knows are highlightable. `true` by default.
+  @IBInspectable open var knobHighlightable: Bool = true {
+    didSet {
+      upperKnob.highlightable = knobHighlightable
+      lowerKnob.highlightable = knobHighlightable
+    }
+  }
+    
   var previousLocation = CGPoint()
   var previouslySelectedKnob = Knob.Neither
   
@@ -243,11 +251,13 @@ import QuartzCore
     
     lowerKnob.frame = CGRect(x: 0, y: 0, width: KnobSize, height: KnobSize)
     lowerKnob.rangeSlider = self
+    lowerKnob.highlightable = knobHighlightable
     lowerKnob.contentsScale = UIScreen.main.scale
     layer.addSublayer(lowerKnob)
     
     upperKnob.frame = CGRect(x: 0, y: 0, width: KnobSize, height: KnobSize)
     upperKnob.rangeSlider = self
+    upperKnob.highlightable = knobHighlightable
     upperKnob.contentsScale = UIScreen.main.scale
     layer.addSublayer(upperKnob)
     

--- a/SwiftRangeSlider/RangeSliderKnob.swift
+++ b/SwiftRangeSlider/RangeSliderKnob.swift
@@ -17,6 +17,8 @@ enum Knob {
 }
 
 class RangeSliderKnob: CALayer {
+  var highlightable: Bool = true
+    
   var highlighted: Bool = false {
     didSet {
       if let superLayer = superlayer, highlighted {
@@ -47,7 +49,7 @@ class RangeSliderKnob: CALayer {
       ctx.addPath(knobPath.cgPath)
       ctx.strokePath()
       
-      if highlighted {
+      if highlighted && highlightable {
         ctx.setFillColor(UIColor(white: 0.0, alpha: 0.1).cgColor)
         ctx.addPath(knobPath.cgPath)
         ctx.fillPath()


### PR DESCRIPTION
I sugget adding a new property to mimic the default UISlider. Currently SwiftRangeSlider Knob is highlighted when touch down. But, the default UISlider is not highlight when touch down.

Added a new property, `knobHighlightable: Bool`.