### PR TITLE
Update to Swift 4.2 syntax

### DIFF
--- a/SwiftRangeSlider/RangeSlider.swift
+++ b/SwiftRangeSlider/RangeSlider.swift
@@ -257,7 +257,7 @@ import QuartzCore
     upperKnob.contentsScale = UIScreen.main.scale
     layer.addSublayer(upperKnob)
     
-    lowerLabel.alignmentMode = kCAAlignmentCenter
+    lowerLabel.alignmentMode = CATextLayerAlignmentMode.center
     lowerLabel.fontSize = labelFontSize
     lowerLabel.frame = CGRect(x: 0, y: 0, width: 75, height: labelFontSize)
     lowerLabel.contentsScale = UIScreen.main.scale
@@ -265,7 +265,7 @@ import QuartzCore
     lowerLabel.foregroundColor = labelColor.cgColor
     layer.addSublayer(lowerLabel)
     
-    upperLabel.alignmentMode = kCAAlignmentCenter
+    upperLabel.alignmentMode = CATextLayerAlignmentMode.center
     upperLabel.fontSize = labelFontSize
     upperLabel.frame = CGRect(x: 0, y: 0, width: 75, height: labelFontSize)
     upperLabel.contentsScale = UIScreen.main.scale
@@ -340,8 +340,8 @@ import QuartzCore
     lowerLabel.foregroundColor = labelColor.cgColor
     upperLabel.foregroundColor = labelColor.cgColor
     
-    lowerLabelTextSize = (lowerLabel.string as! NSString).size(attributes: [NSFontAttributeName : UIFont.systemFont(ofSize: labelFontSize)])
-    upperLabelTextSize = (upperLabel.string as! NSString).size(attributes: [NSFontAttributeName : UIFont.systemFont(ofSize: labelFontSize)])
+    lowerLabelTextSize = (lowerLabel.string as! NSString).size(withAttributes: [NSAttributedString.Key.font : UIFont.systemFont(ofSize: labelFontSize)])
+    upperLabelTextSize = (upperLabel.string as! NSString).size(withAttributes: [NSAttributedString.Key.font : UIFont.systemFont(ofSize: labelFontSize)])
   }
   
   ///Updates the labels positions above the knobs.
@@ -492,7 +492,7 @@ import QuartzCore
   func animateKnob(knob: RangeSliderKnob, selected:Bool) {
     CATransaction.begin()
     CATransaction.setAnimationDuration(0.3)
-    CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseIn))
+    CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeIn))
     
     knob.transform = selected ? CATransform3DMakeScale(selectedKnobDiameterMultiplier, selectedKnobDiameterMultiplier, 1) : CATransform3DIdentity
     
@@ -544,36 +544,3 @@ import QuartzCore
     return CGPoint(x: rect.midX, y: rect.midY)
   }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Currently, SwiftRangeSlider (pod version 2.0.0) no longer compiles in Xcode 10.0 using Swift 4.2 because of some minor syntax changes.

The suggested modifications to RangeSlider.swift fix those issues.